### PR TITLE
Chart.jsの調整とボタンのdisabled化

### DIFF
--- a/app/views/diagnosis/result.html.erb
+++ b/app/views/diagnosis/result.html.erb
@@ -1,13 +1,7 @@
-<div>
-  <div class="container">
-    <h3>火災危険度：<%= @rank.fire_danger_rank %></h3>
-    <h3>建物崩壊危険度：<%= @rank.building_collapse_rank %></h3>
-    <h3>活動困難度：<%= @rank.active_difficulty_rank %></h3>
-    <h3>type_id：<%= @type_id %></h3>
-    <h3>お住まいの地域の総合危険度は...<strong class="text-danger">ランク<%= @rank.total_danger_rank %></strong>です。</h3>
-    <h4>特に<strong class="text-danger"><%= @type.name %></strong>の危険度が高いので、必要な防災グッズを準備しましょう！</h4>
-  </div>
-  <div style="position: relative; height: 60vh; width: 50vh;">
+<div class="text-center pt-5">
+  <h4>お住まいの地域の総合危険度は...<strong class="text-danger">ランク<%= @rank.total_danger_rank %></strong>です。</h4>
+  <h4 class="pb-3">特に<strong class="text-danger"><%= @type.name %></strong>の危険度が高いので、必要な防災グッズを準備しましょう！</h4>
+  <div class="m-auto" style="position: relative; height: 55vh; width: 55vh;">
     <canvas id="myChart"></canvas>
   </div>
   <div class="actions text-center">
@@ -20,7 +14,7 @@ const ctx = document.getElementById('myChart').getContext('2d');
   const myChart = new Chart(ctx, {
     type: 'radar',
     data: {
-      labels: ['建物倒壊危険度', '火災危険度', '災害時困難危険度'],
+      labels: ['火災危険度','建物倒壊危険度', '活動困難危険度'],
       datasets: [{
         label: '危険度グラフ',
         data: [

--- a/app/views/diagnosis/search.html.erb
+++ b/app/views/diagnosis/search.html.erb
@@ -13,7 +13,7 @@
       <%= f.select :town_id, town_options, { include_blank: '選択してください' }, class: "form-control select-children" %>
     </div>
     <div class="actions text-center mt-5">
-      <%= f.submit "診断する", class: "btn btn-outline-dark" %>
+      <%= f.submit "診断する", id: 'search-btn', class: "btn btn-outline-dark disabled" %>
     </div>
   <% end %>
 </div>
@@ -37,7 +37,7 @@
   const replaceChildrenOptions = () => {
     const selectedIndex = document.querySelector('.select-parent').options.selectedIndex;
     const childrenPath = document.querySelector('.select-parent').options[selectedIndex].dataset.childrenPath;
-    const $selectChildren = document.querySelector('.select-children');
+    const selectChildren = document.querySelector('.select-children');
     if (childrenPath !== 'undefined') {
       const xhr = new XMLHttpRequest();
       xhr.open('GET', childrenPath, true);
@@ -46,15 +46,32 @@
       xhr.onreadystatechange = function(){
         if (xhr.readyState == 4 && xhr.status == 200) {
           let results = xhr.response;
-          replaceSelectOptions($selectChildren, results); 
+          replaceSelectOptions(selectChildren, results); 
         } else {
-          replaceSelectOptions($selectChildren, []);
+          replaceSelectOptions(selectChildren, []);
         }
       }
     }
   }
+  
+  const selectButton = () => {
+    const selectedIndex = document.querySelector('.select-children').options.selectedIndex;
+    const searchButton = document.querySelector('#search-btn');
+    if (selectedIndex !== undefined && selectedIndex !== 0) {
+      searchButton.classList.remove('disabled'); 
+    } else {
+      searchButton.classList.add('disabled');
+    }
+  }
+
   const selectParent = document.querySelector('.select-parent');
   selectParent.onchange = () => {
     replaceChildrenOptions();
   }
+
+  const selectChildren = document.querySelector('.select-children');
+  selectChildren.onchange = () => {
+    selectButton();
+  }
+
 </script>

--- a/app/views/goods/_goods.html.erb
+++ b/app/views/goods/_goods.html.erb
@@ -8,7 +8,10 @@
       <br/>
       <p class="mb-auto"><%= good_info.description %></p>
       <div class="actions">
-        <a href="<%= g['itemUrl'] %>" class="btn btn-danger" target="_blank">楽天市場へ</a>
+        <% if good_info.amazon_link %>
+          <a href="<%= good_info.amazon_link %>" class="btn btn-outline-secondary" target="_blank">Amazonで見る</a>
+        <% end %>
+        <a href="<%= g['itemUrl'] %>" class="btn btn-outline-danger" target="_blank">楽天市場で見る</a>
       </div>
     </div>  
   </div>


### PR DESCRIPTION
## 概要

chart.jsの位置調整と、ボタンのdisabled化とamazon_linkがある商品についてはamazonのボタンも表示されるようにしました！（まだmodelのamazon_linkは全てnullで入力されているため、まだ表示はされませんが、、、今後博野さんにgoods.csvの更新いただいた段階で変更が反映されると思います！）

## 確認方法

以下の変更を確認してください。

1. 診断画面で町丁目名を選ばないとボタンが選択できないようになっているか？
2. 診断結果画面ではchart.jsが真ん中に表示されているか。
3. chart.jsは項目も修正しました。（可能であれば項目と数値に齟齬がないかを確認してください）

## 影響範囲

３つのファイルを修正しました。
・app/views/diagnosis/search.html.erb
・app/views/diagnosis/result.html.erb
・app/views/goods/_goods.html.erb

## チェックリスト

以下の確認をお願いします。
- [ ] 診断画面のボタンは町丁目名が選ばれていないと押せない状況になっているか。
- [ ] chart.jsが真ん中に位置しており、正しく表示されているか。

## コメント

説明が必要な部分はおしゃってください！よろしくお願いいたします！