### PR TITLE
デプロイがうまくいかなかった為、node.jsのバージョンを指定してデプロイ

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,9 @@
 {
   "name": "disaster-goods",
   "private": true,
+  "engines": {
+    "node": "16.17.0"
+  },
   "dependencies": {
     "@fortawesome/fontawesome-free": "5.15.4",
     "@popperjs/core": "^2.11.6",


### PR DESCRIPTION
## 概要

Closes #26 
#36をデプロイした際に、`Node.js v18.11.0`
となってしまい、デプロイがうまくいかなかった。
そのため`package.json`でバージョンを記載して、デプロイを行った。

## 確認方法

行った修正をレビュアーが確認するための手順を記載しましょう。例えば以下のように。

1. `package.json`に、
```
"engines": {
    "node": "16.17.0"
  },
```
を記載していることを確認してください。

## 影響範囲

・package.json

## チェックリスト

## コメント

こちらに記載されていた通りに修正を行いました。
https://devcenter.heroku.com/ja/articles/nodejs-support#specifying-a-node-js-version
