### PR TITLE
Add:災害危険度をアコーディオンに変更

### DIFF
--- a/app/views/diagnosis/result.html.erb
+++ b/app/views/diagnosis/result.html.erb
@@ -4,13 +4,26 @@
   <div class="chart-area m-auto">
     <canvas id="myChart"></canvas>
   </div>
-  <div class="hazard-discription mx-auto">
-    <ul class="text-start">
-      <li>火災危険度　　・・・火災の発生による延焼の危険性</li>
-      <li>建物倒壊危険度・・・建物倒壊の危険性</li>
-      <li>活動困難危険度・・・道路・公園等の整備状況による災害時の活動の困難さ</li>
-    </ul>
-  </div>
+
+  <div class="accordion" id="hazard">
+  <div class="accordion-item">
+    <h1 class="accordion-header" id="headingTwo">
+      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+        災害危険度とは？
+      </button>
+    </h1>
+    <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#hazard">
+      <div class="accordion-body">
+      <div class="hazard-discription mx-auto">
+        <ul class="text-start">
+          <li>火災危険度　　・・・火災の発生による延焼の危険性</li>
+          <li>建物倒壊危険度・・・建物倒壊の危険性</li>
+          <li>活動困難危険度・・・道路・公園等の整備状況による災害時の活動の困難さ</li>
+        </ul>
+      </div>
+      </div>
+    </div>
+
   <div class="actions text-center pt-4 mb-5">
     <%= link_to "おすすめグッズを見る", goods_path(type_id: @type_id), class: "main-btn" %>
   </div>


### PR DESCRIPTION
## 概要

結果ページに表示される災害危険度の説明をアコーディオンで折り畳んで表示するようにしました。

## 確認方法

行った修正をレビュアーが確認するための手順を記載しましょう。例えば以下のように。

1. 結果ページに飛んで、災害危険度の説明がアコーディオンになっているかを確認してください

https://user-images.githubusercontent.com/94298144/218312801-ba21b2f7-45d8-493b-a42b-b24ba4e7bbf6.mov


## 影響範囲

行った修正が影響するであろう範囲を記載しましょう。レビュアーが修正の影響範囲を予測する助けになります。

## チェックリスト

プロジェクトごとにパスしなければならないルールを定義しておきましょう。例えば以下のように。

- [ ] 災害危険度の説明がアコーディオンになっている


## コメント

- PCで表示されると長くなってしまい見辛い為改善したいですが、やり方がわかってない為一旦こちらであげています

