### PR TITLE
Update: グッズの取得画像を大きくした

### DIFF
--- a/app/views/goods/_goods.html.erb
+++ b/app/views/goods/_goods.html.erb
@@ -1,7 +1,7 @@
 <div class="col-md-10 m-auto">
   <div class="row g-0 border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative">
     <div class="col-auto d-none d-lg-block">
-      <img src="<%= g['mediumImageUrls'][0] %>" class="bd-placeholder-img" width="250" height="250" >
+      <img src="<%= g['mediumImageUrls'][0].sub('_ex=128x128','_ex=560x560') %>" class="bd-placeholder-img" width="250" height="250" >
     </div>
     <div class="col p-4 d-flex flex-column position-static">
       <h4 class="mb-0"><%= good_info.name %></h4>


### PR DESCRIPTION
## 概要
アイテムの画像の粗さをなくすために、取得画像を大きくしました。

1. _goods.html.erbのコードを書き換えた。

## 確認方法
画像の粗さがないか、アイテムの画像を取得できるか確認してください。
[![Image from Gyazo](https://i.gyazo.com/0573f167ad345a17dc42128638b9a14c.png)](https://gyazo.com/0573f167ad345a17dc42128638b9a14c)

## 影響範囲

どんな商品かっていう、ユーザーの判断の助けになります。

## チェックリスト

- [x] 画像の粗さがなくなっている

## コメント

スマホでは確認できないため、PCモニターで確認お願いします。
