### PR TITLE
[Feat] 診断結果画面のリバイス

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,7 @@
 yarn-debug.log*
 .yarn-integrity
 
+/package-lock.json
 .env
 
 # Ignore vendor

--- a/app/controllers/diagnosis_controller.rb
+++ b/app/controllers/diagnosis_controller.rb
@@ -7,6 +7,8 @@ class DiagnosisController < ApplicationController
   end
 
   def result
+    @district = District.find(params[:district_id])
+    @town = Town.find(params[:town_id])
     @rank = Rank.find_by(town_id: params[:town_id])
     @fire_danger_rank = @rank.fire_danger_rank.to_json.html_safe
     @building_collapse_rank = @rank.building_collapse_rank.to_json.html_safe

--- a/app/views/diagnosis/result.html.erb
+++ b/app/views/diagnosis/result.html.erb
@@ -1,29 +1,76 @@
-<div class="result_area text-center pt-5">
-  <h4>お住まいの地域の総合危険度は...<strong class="text-danger">ランク<%= @rank.total_danger_rank %></strong>です。</h4>
-  <h4 class="pb-3">特に<strong class="text-danger"><%= @type.name %></strong>の危険度が高いので、必要な防災グッズを準備しましょう！</h4>
-  <div class="chart-area m-auto">
+<div class="result_area pt-5">
+  <div class="text-center">
+    <h4><strong class="text-danger"><%= @district.name  %> <%= @town.name %></strong>の総合危険度は<strong class="text-danger">ランク<%= @rank.total_danger_rank %></strong>です。</h4>
+    <% if @type.id == 7 && @rank.total_danger_rank == 1 %>
+      <h4 class="pb-3"><strong class="text-danger">全てのランクが最も低く安全</strong>です。有事に備えて必要な防災グッズを準備しましょう！</h4>
+    <% else %>
+      <h4 class="pb-3"><strong class="text-danger"><%= @type.name %></strong>の危険度が高いので、必要な防災グッズを準備しましょう！</h4>
+    <% end %>
+  </div>
+  <div class="chart-area m-auto mb-4">
     <canvas id="myChart"></canvas>
   </div>
-
-  <div class="accordion" id="hazard">
-  <div class="accordion-item">
-    <h1 class="accordion-header" id="headingTwo">
-      <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
-        災害危険度とは？
-      </button>
-    </h1>
-    <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo" data-bs-parent="#hazard">
-      <div class="accordion-body">
-      <div class="hazard-discription mx-auto">
-        <ul class="text-start">
-          <li>火災危険度　　・・・火災の発生による延焼の危険性</li>
-          <li>建物倒壊危険度・・・建物倒壊の危険性</li>
-          <li>活動困難危険度・・・道路・公園等の整備状況による災害時の活動の困難さ</li>
-        </ul>
+  <div class="container mb-5">
+    <div class="accordion" id="hazard">
+      <h4 class="text-left mb-3">災害危険度とは？</h4>
+      <div class="accordion-item">
+        <h1 class="accordion-header" id="flush-headingOne">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseOne" aria-expanded="false" aria-controls="collapseOne">
+          火災危険度について
+          </button>
+        </h1>
       </div>
+      <div id="collapseOne" class="accordion-collapse collapse" aria-labelledby="headingOne">
+        <div class="accordion-body">
+          <div class="hazard-discription">
+            <p>火災危険度の説明を記載</p>
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h1 class="accordion-header" id="headingTwo">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseTwo" aria-expanded="false" aria-controls="collapseTwo">
+          建物倒壊危険度について
+          </button>
+        </h1>
+      </div>
+      <div id="collapseTwo" class="accordion-collapse collapse" aria-labelledby="headingTwo">
+        <div class="accordion-body">
+          <div class="hazard-discription">
+            <p>建物倒壊危険度の説明を記載</p>
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h1 class="accordion-header" id="headingTwo">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseThree" aria-expanded="false" aria-controls="collapseThree">
+          活動困難危険度について
+          </button>
+        </h1>
+      </div>
+      <div id="collapseThree" class="accordion-collapse collapse" aria-labelledby="headingThree">
+        <div class="accordion-body">
+          <div class="hazard-discription">
+            <p>活動困難危険度の説明を記載</p>
+          </div>
+        </div>
+      </div>
+      <div class="accordion-item">
+        <h1 class="accordion-header" id="headingTwo">
+          <button class="accordion-button collapsed" type="button" data-bs-toggle="collapse" data-bs-target="#collapseFour" aria-expanded="false" aria-controls="collapseFour">
+          総合危険度について
+          </button>
+        </h1>
+      </div>
+      <div id="collapseFour" class="accordion-collapse collapse" aria-labelledby="headingFour">
+        <div class="accordion-body">
+          <div class="hazard-discription">
+            <p>総合危険度の説明を記載</p>
+          </div>
+        </div>
       </div>
     </div>
-
+  </div>
   <div class="actions text-center pt-4 mb-5">
     <%= link_to "おすすめグッズを見る", goods_path(type_id: @type_id), class: "main-btn" %>
   </div>


### PR DESCRIPTION
## 概要
４点ほど実装しましたので、ご確認お願いします。
・結果ページの冒頭に地域を記載（`お住まいの地域`ではなく、`墨田区〇〇３丁目`といった記載に変更）
・総合危険度１でかつ、全ての危険度が１である場合の説明を変更
・アコーディオンを３つ実装（説明文は未記載です。。。）
・`gitignoreにpackage-lock.json`を追加

## 確認方法
`git pull origin revise_result_page:revise_result_page`などでローカルでブランチをプルし、
実装画面が以下のようになっているかご確認ください。
[![Image from Gyazo](https://i.gyazo.com/a3ed268f76b637b66d05b55f5cd58501.png)](https://gyazo.com/a3ed268f76b637b66d05b55f5cd58501)

## 影響範囲
以下のファイルを変更しました。
・.gitignore
・app/controllers/result_controller.rb
・app/views/diagnosis/result.html.erb

## チェックリスト

- [x] 全危険度１の説明文が`全てのランクが最も低く安全です。有事に備えて必要な防災グッズを準備しましょう！`となっていること。
- [x] 診断結果画面の冒頭に区市町村名が入っていること
- [x] アコーディオンの体裁が崩れていないこと。

## コメント
適宜マージされたタイミングで`package-lock.json`を`git rm`で削除したいと思います。
次回ミーティングで作業できればと思います。
