### PR TITLE
Add: 災害グッズページのアイテム欄をレスポンシブに

### DIFF
--- a/app/assets/stylesheets/goods/_goods.scss
+++ b/app/assets/stylesheets/goods/_goods.scss
@@ -1,0 +1,10 @@
+.goods {
+  width: 390px;
+  height: 390px;
+}
+@media screen and (max-width: 500px) {
+  .goods {
+    width: 350px;
+    height: 350px;
+  }
+}

--- a/app/assets/stylesheets/goods/_goods.scss
+++ b/app/assets/stylesheets/goods/_goods.scss
@@ -1,10 +1,16 @@
 .goods {
-  width: 390px;
-  height: 390px;
+  width: 350px;
+  height: 350px;
 }
-@media screen and (max-width: 500px) {
+@media screen and (min-width: 500px) {
   .goods {
-    width: 350px;
-    height: 350px;
+    width: 560px;
+    height: 560px;
+  }
+}
+@media screen and (min-width: 991px) {
+  .goods {
+    width: 380px;
+    height: 380px;
   }
 }

--- a/app/assets/stylesheets/styles.scss
+++ b/app/assets/stylesheets/styles.scss
@@ -5,3 +5,4 @@
 @import "ui/button";
 @import "ui/label";
 @import "diagnosis/result";
+@import "goods/goods"

--- a/app/views/goods/_goods.html.erb
+++ b/app/views/goods/_goods.html.erb
@@ -1,9 +1,9 @@
 <div class="col-md-10 m-auto">
   <div class="row g-0 border rounded overflow-hidden flex-md-row mb-4 shadow-sm h-md-250 position-relative">
-    <div class="col-auto d-none d-lg-block">
-      <img src="<%= g['mediumImageUrls'][0].sub('_ex=128x128','_ex=560x560') %>" class="bd-placeholder-img" width="250" height="250" >
+    <div class="col-auto">
+      <img src="<%= g['mediumImageUrls'][0].sub('_ex=128x128','_ex=560x560') %>" class="bd-placeholder-img goods" >
     </div>
-    <div class="col p-4 d-flex flex-column position-static">
+    <div class="col-lg p-4 d-flex flex-column position-static">
       <h4 class="mb-0"><%= good_info.name %></h4>
       <br/>
       <p class="mb-auto"><%= good_info.description %></p>


### PR DESCRIPTION
## 概要
グッズページを以下の方法でレスポンシブに変えました。

1. 幅が一定以上小さくなったら、アイテムとアイテム説明欄を縦並べにする。
2. 幅によって画像の大きさをコントロールする。

スマホサイズとパソコンサイズには適応できていると思います。
_goods.scssによって画像幅をコントロールしています。

## 確認方法
git pull origin item_responsive:item_responsiveなどでローカルブランチをプルして、
`rails s`で起動し、グッズページにてデベロッパーツールを使って、幅を調整しながら確認してください。
## 影響範囲
## チェックリスト

- [ ] パソコンとスマホサイズ、タブレットサイズにレスポンシブに対応できているか？


## コメント

問題なければapproveお願いします
