### PR TITLE
Submitボタンのバグを修正

### DIFF
--- a/app/views/diagnosis/search.html.erb
+++ b/app/views/diagnosis/search.html.erb
@@ -58,6 +58,7 @@
   const selectButton = () => {
     const selectedIndex = document.querySelector('.select-children').options.selectedIndex;
     const searchButton = document.querySelector('#search-btn');
+    console.log(selectedIndex)
     if (selectedIndex !== undefined && selectedIndex !== 0) {
       searchButton.removeAttribute('disabled'); 
     } else {
@@ -66,9 +67,11 @@
   }
 
   const selectParent = document.querySelector('.select-parent');
+  const searchButton = document.querySelector('#search-btn');
   selectParent.onchange = () => {
     selectChildren.setAttribute('disabled', true);
     replaceChildrenOptions();
+    searchButton.setAttribute('disabled', true);
   }
 
   const selectChildren = document.querySelector('.select-children');

--- a/app/views/diagnosis/search.html.erb
+++ b/app/views/diagnosis/search.html.erb
@@ -58,7 +58,6 @@
   const selectButton = () => {
     const selectedIndex = document.querySelector('.select-children').options.selectedIndex;
     const searchButton = document.querySelector('#search-btn');
-    console.log(selectedIndex)
     if (selectedIndex !== undefined && selectedIndex !== 0) {
       searchButton.removeAttribute('disabled'); 
     } else {


### PR DESCRIPTION
## 概要
診断ボタンを選び直して下のセレクトボックスがリセットされた際、診断ボタンがdisabledにならない現象が発生。
そのバグを修正しました。

## 確認方法

`git pull origin fix_bug:fix_bug`でローカルにブランチをプルして以下の手順でご確認をお願いします。

1. 診断結果画面で、まず、上の区市町名と下の町丁目名を適当に選択してください。
2. 上の区市町名を別のものに選び直してください。
3. 下の町丁目名がリセットされた時に「診断ボタン」がdisabledになっているかご確認ください。

## 影響範囲
以下のファイルのみ修正しました。
app/views/diagnosis/search.html.erb


## コメント

わかりづらいバグ修正ですが、ご確認よろしくお願いいたします！